### PR TITLE
Make cmake work better

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,46 @@
-cmake_minimum_required(VERSION 2.8.9)
-project(concordpp)
+cmake_minimum_required(VERSION 3.1.3 FATAL_ERROR)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+# Force external build because source tree builds make a mess.
+if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR} AND NOT WIN32)
+	    message(FATAL_ERROR "You can not use CMake to build from the root of it's source tree! Remove the CMakeCache.txt file from this directory, then create a separate directory (either below this directory or elsewhere), and then re-run CMake from there.")
+endif(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR} AND NOT WIN32)
+
+project(concordpp CXX)
+enable_language(C)
+
+include(ExternalProject)
+
 #set(CMAKE_BUILD_TYPE Release)
+# Use boost multithreading
+set(Boost_USE_MULTITHREADED  ON)
 find_package(Boost 1.58 REQUIRED COMPONENTS system)
-find_package(OpenSSL REQUIRED openssl)
 
-# Disable tests for JSON
-set(BuildTests OFF CACHE INTERNAL "" FORCE)
+find_package(OpenSSL REQUIRED openssl)
+find_package(CURL REQUIRED)
+# Required because boost/C++11 uses pthread
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libs/websocketpp)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libs/restclient-cpp)
 
-
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/libs/websocketpp ${CMAKE_CURRENT_SOURCE_DIR}/libs/json)
+add_library(${PROJECT_NAME} ${SOURCES})
+set_target_properties(${PROJECT_NAME}
+	PROPERTIES LINKER_LANGUAGE CXX
+	LINK_FLAGS "${LINKFLAGS}"
+	# Require C++11, NOTE: this requires us to use CMake 3.1.3 at minimum
+	CXX_STANDARD 11
+	CXX_STANDARD_REQUIRED YES
+	CXX_EXTENSIONS NO # use -std=c++11 and not -std=gnu++11
+)
 
-add_library(concordpp ${SOURCES})
-target_include_directories(concordpp INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/libs/websocketpp ${CMAKE_CURRENT_SOURCE_DIR}/libs/json)
-target_link_libraries(concordpp ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} pthread boost_thread restclient-cpp curl)
+include_directories(
+		${CMAKE_SOURCE_DIR}/include
+		${Boost_INCLUDE_DIRS}
+		${CMAKE_CURRENT_SOURCE_DIR}/libs/websocketpp
+		${CMAKE_CURRENT_SOURCE_DIR}/libs/json
+		${CURL_INCLUDE_DIRS}
+)
+target_link_libraries(${PROJECT_NAME} ${PROJECT_LINK_LIBS} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} ${CURL_LIBRARIES} Threads::Threads restclient-cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set_target_properties(${PROJECT_NAME}
 )
 
 include_directories(
-		${CMAKE_SOURCE_DIR}/include
+		${CMAKE_CURRENT_SOURCE_DIR}/include
 		${Boost_INCLUDE_DIRS}
 		${CMAKE_CURRENT_SOURCE_DIR}/libs/websocketpp
 		${CMAKE_CURRENT_SOURCE_DIR}/libs/json


### PR DESCRIPTION
I have added some stuff to make cmake work a bit better between not just linux distributions but also on windows if you decide to port the project to windows.

The following fixes were made:
- CMake now tries to find boost, curl, and the required threading dependencies itself (curl was actually a missing dependency)
- CMake now downloads the latest version of nlohmann/json automatically on configure so the local version can be removed from the repository.
- Disallowed source directory builds (because those are messy) and instead encourage you make a build directory
- Made CMake determine what C++ flags we use for setting the C++11 standard, this guarantees that cmake always uses C++11 or fails to configure.
- I was forced to change the CMake required version to 3.1.3 because of the C++ standard stuff above. Most systems that support C++11 also have cmake 3.1.3 or higher