### PR TITLE
Dump boost threads + small clean up

### DIFF
--- a/include/concordpp.h
+++ b/include/concordpp.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "internal/debug.h"
 #include "rest_client.h"
 #include "gateway_client.h"

--- a/include/gateway/callback.h
+++ b/include/gateway/callback.h
@@ -1,6 +1,4 @@
-#ifndef CALLBACK_H
-#define CALLBACK_H
-
+#pragma once
 #include <functional>
 #include <json.hpp>
 
@@ -19,4 +17,3 @@ namespace concordpp {
     }
 }
 
-#endif

--- a/include/gateway/callback_handler.h
+++ b/include/gateway/callback_handler.h
@@ -1,5 +1,4 @@
-#ifndef CALLBACK_HANDLER_H
-#define CALLBACK_HANDLER_H
+#pragma once
 #include "gateway/callback.h"
 #include "gateway/command.h"
 #include <vector>
@@ -17,4 +16,3 @@ namespace concordpp {
     }
 }
 
-#endif

--- a/include/gateway/command.h
+++ b/include/gateway/command.h
@@ -1,6 +1,4 @@
-#ifndef COMMAND_H
-#define COMMAND_H
-
+#pragma once
 #include "gateway/callback.h"
 
 namespace concordpp {
@@ -16,4 +14,3 @@ namespace concordpp {
     }
 }
 
-#endif

--- a/include/gateway/web_socket.h
+++ b/include/gateway/web_socket.h
@@ -1,6 +1,4 @@
-#ifndef GATEWAY_WEB_SOCKET_H
-#define GATEWAY_WEB_SOCKET_H
-
+#pragma once
 #include <websocketpp/config/asio_client.hpp>
 #include <websocketpp/client.hpp>
 #include <boost/thread/thread.hpp>
@@ -58,4 +56,4 @@ namespace concordpp {
         };
     }
 }
-#endif
+

--- a/include/gateway/web_socket.h
+++ b/include/gateway/web_socket.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <websocketpp/config/asio_client.hpp>
 #include <websocketpp/client.hpp>
-#include <boost/thread/thread.hpp>
+#include <mutex>
+#include <atomic>
+#include <condition_variable>
 #include "gateway/callback_handler.h"
 
 namespace concordpp {
@@ -33,8 +35,10 @@ namespace concordpp {
             int heartbeat_interval;
             bool heartbeat_received;
             connection_type connection_route;
-            bool heartbeat_is_running;
-            boost::thread *heartbeat_thread;
+            std::atomic<bool> heartbeat_is_running;
+            std::mutex heartbeatlock;
+            std::condition_variable cv;
+            std::thread *heartbeat_thread;
 
             callback_handler *cb_handler;
 

--- a/include/gateway_client.h
+++ b/include/gateway_client.h
@@ -1,5 +1,4 @@
-#ifndef GATEWAY_CLIENT_H
-#define GATEWAY_CLIENT_H
+#pragma once
 
 #include <string>
 #include "gateway/web_socket.h"
@@ -47,4 +46,3 @@ namespace concordpp {
     }
 }
 
-#endif

--- a/include/internal/debug.h
+++ b/include/internal/debug.h
@@ -1,5 +1,4 @@
-#ifndef INTERNAL_DEBUG_H
-#define INTERNAL_DEBUG_H
+#pragma once
 #include <string>
 namespace concordpp {
     namespace debug {
@@ -20,4 +19,3 @@ namespace concordpp {
     }
 }
 
-#endif

--- a/include/rest/api_call.h
+++ b/include/rest/api_call.h
@@ -1,6 +1,4 @@
-#ifndef API_CALL_H
-#define API_CALL_H
-
+#pragma once
 namespace concordpp {
     namespace rest {
         enum rest_request_type {
@@ -12,4 +10,3 @@ namespace concordpp {
     }
 }
 
-#endif

--- a/include/rest_client.h
+++ b/include/rest_client.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <functional>
-#include <boost/thread/thread.hpp>
 #include <restclient-cpp/connection.h>
 #include <restclient-cpp/restclient.h>
 #include <json.hpp>

--- a/include/rest_client.h
+++ b/include/rest_client.h
@@ -1,6 +1,4 @@
-#ifndef REST_CLIENT_H
-#define REST_CLIENT_H
-
+#pragma once
 #include <functional>
 #include <boost/thread/thread.hpp>
 #include <restclient-cpp/connection.h>
@@ -40,4 +38,3 @@ namespace concordpp {
     }
 }
 
-#endif

--- a/src/gateway_client.cpp
+++ b/src/gateway_client.cpp
@@ -12,12 +12,11 @@ gateway_client::gateway_client(std::string token) {
 }
 
 gateway_client::~gateway_client() {
-    if(gateway_connect_state != CLOSE) {
+    if(gateway_connect_state != CLOSE)
         stop();
-    }
-    if(socket != NULL) {
+
+    if(socket)
         delete socket;
-    }
 }
 
 void gateway_client::connect() {
@@ -65,8 +64,11 @@ void gateway_client::add_command(std::string command_name, std::function<void(nl
 void gateway_client::set_status(concordpp::gateway::status_types::status status, std::string playing, bool afk, std::time_t idle_since) {
     json data;
     data["op"] = 3;
-    if(idle_since == -1) data["d"]["since"] = NULL;
-    else data["d"]["since"] = idle_since;
+    if (idle_since == -1)
+        data["d"]["since"] = NULL;
+    else
+        data["d"]["since"] = idle_since;
+
     data["d"]["status"] = status;
     data["d"]["game"]["name"] = playing;
     data["d"]["afk"] = afk;

--- a/src/rest_client.cpp
+++ b/src/rest_client.cpp
@@ -1,4 +1,6 @@
 #include "rest_client.h"
+#include <thread>
+#include <chrono>
 
 using namespace concordpp::rest;
 
@@ -9,7 +11,10 @@ rest_client::rest_client(std::string token) {
 }
 
 rest_client::~rest_client() {
-        // Wait for all HTTP threads to finish
-    while(http_thread_count > 0) {}
+    // Wait for all HTTP threads to finish
+    // Use sleep here so we don't do 100% cpu doing nothing but waiting. - Justasic
+    while(http_thread_count > 0)
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
     RestClient::disable();
 }


### PR DESCRIPTION
C++11's std::thread is based on boost::thread and aside from it not having boost::thread::interrupt() they're identical. I replaced all references to boost::thread or boost::this_thread with the standard lib equivalents. To replace boost::thread::interrupt(), I used a condition variable for waiting and an atomic boolean so the thread can be interrupted at many points.

There was another condition in src/rest_client.cpp Line 14 where the application can consume high CPU usage for no reason waiting for threads to terminate (possibly causing unwanted system slowdown), I added a small wait condition but this may want to be changed from milliseconds to nanoseconds if the wait time really doesn't need to be very long.

As a small fix, I did some stuff to make things a bit more readable but these are really minor. This also changes `#define HEADER_NAME_HERE_H` to just `#pragma once` because `#pragma once` is part of the C++11 standard (and the C11 standard too I believe) so all modern compilers will support it.

NOTE: I have not done runtime tests on this so let me know if anything is horribly broken.